### PR TITLE
Update 'qs' package version in package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7505,7 +7505,7 @@
     "http-errors": "2.0.0",
     "iconv-lite": "0.4.24",
     "on-finished": "2.4.1",
-    "qs": "6.13.0",
+  "6.13.0",
     "raw-body": "2.5.2",
     "type-is": "~1.6.18",
     "unpipe": "1.0.0"
@@ -9904,7 +9904,7 @@
     "parseurl": "~1.3.3",
     "path-to-regexp": "0.1.12",
     "proxy-addr": "~2.0.7",
-    "qs": "6.13.0",
+    "qs": ">=6.15.2",
     "range-parser": "~1.2.1",
     "safe-buffer": "5.2.1",
     "send": "0.19.0",


### PR DESCRIPTION
Updated 'qs' package version to be greater than or equal to 6.15.2.